### PR TITLE
Solve MimeType error

### DIFF
--- a/missing-persons-viewer-vite/index.html
+++ b/missing-persons-viewer-vite/index.html
@@ -1,16 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RCMP Missing Persons Database Tool</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>RCMP Missing Persons Database Tool</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="src/main.tsx"></script>
+  </body>
 </html>


### PR DESCRIPTION
Encountered blank screen with this error on Chrome & Firefox:

```
The stylesheet https://rcmp-db-missing-persons.netlify.app/missing-persons/assets/index-f817a89d.css was not loaded because its MIME type, "text/html", is not "text/css".
```
Error did not happen when I ran the project locally. May be caused by leading forward slash in script tag in index.html. Changed path from "/src/main.tsx" to "src/main.tsx". Didn't break the app locally and might work for the hosted version?